### PR TITLE
Latest Release - Ver 1.4

### DIFF
--- a/Plugins/Aspose_for_JetBrains/.idea/vcs.xml
+++ b/Plugins/Aspose_for_JetBrains/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/Plugins/Aspose_for_JetBrains/.idea/workspace.xml
+++ b/Plugins/Aspose_for_JetBrains/.idea/workspace.xml
@@ -1,7 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ChangeListManager">
-    <list default="true" id="d75ba661-2dbd-48bf-a800-246e1034c74e" name="Default" comment="" />
+    <list default="true" id="d75ba661-2dbd-48bf-a800-246e1034c74e" name="Default" comment="">
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/.idea/workspace.xml" afterPath="$PROJECT_DIR$/.idea/workspace.xml" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/META-INF/plugin.xml" afterPath="$PROJECT_DIR$/META-INF/plugin.xml" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/src/com/aspose/examples/AsposeExampleDialog.java" afterPath="$PROJECT_DIR$/src/com/aspose/examples/AsposeExampleDialog.java" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/src/com/aspose/examples/AsposeExamplePanel.java" afterPath="$PROJECT_DIR$/src/com/aspose/examples/AsposeExamplePanel.java" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/src/com/aspose/examples/otherexamples/OtherExamplesManager.java" afterPath="$PROJECT_DIR$/src/com/aspose/examples/otherexamples/OtherExamplesManager.java" />
+    </list>
     <ignored path="AsposeIntellJ.iws" />
     <ignored path=".idea/workspace.xml" />
     <ignored path="$PROJECT_DIR$/out/" />
@@ -83,22 +89,12 @@
     <favorites_list name="AsposeIntelliJ" />
   </component>
   <component name="FileEditorManager">
-    <leaf SIDE_TABS_SIZE_LIMIT_KEY="300">
-      <file leaf-file-name="README.md" pinned="false" current-in-tab="true">
-        <entry file="file://$PROJECT_DIR$/README.md">
-          <provider selected="true" editor-type-id="text-editor">
-            <state vertical-scroll-proportion="-1.8202765">
-              <caret line="24" column="0" selection-start-line="24" selection-start-column="0" selection-end-line="24" selection-end-column="0" />
-              <folding />
-            </state>
-          </provider>
-        </entry>
-      </file>
-      <file leaf-file-name="plugin.xml" pinned="false" current-in-tab="false">
+    <leaf>
+      <file leaf-file-name="plugin.xml" pinned="false" current-in-tab="true">
         <entry file="file://$PROJECT_DIR$/META-INF/plugin.xml">
           <provider selected="true" editor-type-id="text-editor">
-            <state vertical-scroll-proportion="-9.153846">
-              <caret line="20" column="14" selection-start-line="20" selection-start-column="14" selection-end-line="20" selection-end-column="14" />
+            <state vertical-scroll-proportion="0.16091955">
+              <caret line="20" column="16" selection-start-line="20" selection-start-column="16" selection-end-line="20" selection-end-column="16" />
               <folding />
             </state>
           </provider>
@@ -111,6 +107,9 @@
       <setting name="OPEN_NEW_TAB" value="false" />
     </FindUsagesManager>
   </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
   <component name="GradleLocalSettings">
     <option name="externalProjectsViewState">
       <projects_view />
@@ -120,8 +119,11 @@
     <option name="CHANGED_PATHS">
       <list>
         <option value="$PROJECT_DIR$/src/com/aspose/utils/AsposeJavaComponents.java" />
-        <option value="$PROJECT_DIR$/META-INF/plugin.xml" />
         <option value="$PROJECT_DIR$/README.md" />
+        <option value="$PROJECT_DIR$/src/com/aspose/examples/AsposeExamplePanel.java" />
+        <option value="$PROJECT_DIR$/src/com/aspose/examples/AsposeExampleDialog.java" />
+        <option value="$PROJECT_DIR$/src/com/aspose/examples/otherexamples/OtherExamplesManager.java" />
+        <option value="$PROJECT_DIR$/META-INF/plugin.xml" />
       </list>
     </option>
   </component>
@@ -135,7 +137,7 @@
   <component name="ProjectFrameBounds">
     <option name="x" value="-8" />
     <option name="y" value="-8" />
-    <option name="width" value="1378" />
+    <option name="width" value="1382" />
     <option name="height" value="744" />
   </component>
   <component name="ProjectInspectionProfilesVisibleTreeState">
@@ -192,8 +194,6 @@
       <foldersAlwaysOnTop value="true" />
     </navigator>
     <panes>
-      <pane id="Scope" />
-      <pane id="PackagesPane" />
       <pane id="ProjectPane">
         <subPane>
           <PATH>
@@ -228,7 +228,9 @@
           </PATH>
         </subPane>
       </pane>
+      <pane id="PackagesPane" />
       <pane id="Scratches" />
+      <pane id="Scope" />
     </panes>
   </component>
   <component name="PropertiesComponent">
@@ -252,22 +254,24 @@
     <property name="options.searchVisible" value="true" />
     <property name="SearchEverywhereHistoryKey" value="invokeAndWait&#9;PSI&#9;JAVA://com.intellij.debugger.impl.InvokeAndWaitThread&#10;later&#9;PSI&#9;JAVA://com.intellij.openapi.wm.impl.commands.InvokeLaterCmd&#10;extractFolder&#9;PSI&#9;JAVA://com.aspose.utils.AsposeComponentsManager#extractFolder&#10;downloadComponents&#9;PSI&#9;JAVA://com.aspose.wizards.AsposeModuleWizardStep#downloadComponents&#10;copyDirectory&#9;PSI&#9;JAVA://com.aspose.utils.AsposeComponentsManager#copyDirectory&#10;AsposeComponentsManager.copyDirectory&#9;PSI&#9;JAVA://com.aspose.utils.AsposeComponentsManager#copyDirectory" />
     <property name="LayoutCode.rearrangeEntriesJava" value="false" />
+    <property name="settings.editor.selected.configurable" value="preferences.pluginManager" />
+    <property name="settings.editor.splitter.proportion" value="0.2" />
   </component>
   <component name="RecentsManager">
-    <key name="MoveFile.RECENT_KEYS">
-      <recent name="C:\Users\Adeel Ilyas\IdeaProjects\AsposeIntelliJ" />
-    </key>
-    <key name="CopyClassDialog.RECENTS_KEY">
-      <recent name="com.aspose.wizards.execution" />
-      <recent name="com.aspose.utils" />
-      <recent name="com.aspose.wizards" />
-    </key>
     <key name="CopyFile.RECENT_KEYS">
       <recent name="C:\Users\Adeel Ilyas\IdeaProjects\AsposeIntelliJ\src\com\aspose\examples" />
       <recent name="C:\Users\Adeel Ilyas\IdeaProjects\AsposeIntelliJ" />
       <recent name="C:\Users\Adeel Ilyas\IdeaProjects\AsposeIntelliJ\src\com\aspose\utils" />
       <recent name="C:\Users\Adeel Ilyas\IdeaProjects\AsposeIntelliJ\src\resources" />
       <recent name="C:\Users\Adeel Ilyas\IdeaProjects\AsposeIntelliJ\src" />
+    </key>
+    <key name="CopyClassDialog.RECENTS_KEY">
+      <recent name="com.aspose.wizards.execution" />
+      <recent name="com.aspose.utils" />
+      <recent name="com.aspose.wizards" />
+    </key>
+    <key name="MoveFile.RECENT_KEYS">
+      <recent name="C:\Users\Adeel Ilyas\IdeaProjects\AsposeIntelliJ" />
     </key>
   </component>
   <component name="RunManager" selected="Plugin.AsposeIntelliJ">
@@ -397,8 +401,58 @@
       <patterns />
       <method />
     </configuration>
+    <configuration default="true" type="JUnitTestDiscovery" factoryName="JUnit Test Discovery" changeList="All">
+      <extension name="coverage" enabled="false" merge="false" sample_coverage="true" runner="idea" />
+      <module name="" />
+      <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
+      <option name="ALTERNATIVE_JRE_PATH" />
+      <option name="PACKAGE_NAME" />
+      <option name="MAIN_CLASS_NAME" />
+      <option name="METHOD_NAME" />
+      <option name="TEST_OBJECT" value="class" />
+      <option name="VM_PARAMETERS" />
+      <option name="PARAMETERS" />
+      <option name="WORKING_DIRECTORY" />
+      <option name="ENV_VARIABLES" />
+      <option name="PASS_PARENT_ENVS" value="true" />
+      <option name="TEST_SEARCH_SCOPE">
+        <value defaultName="singleModule" />
+      </option>
+      <envs />
+      <patterns />
+      <method />
+    </configuration>
     <configuration default="true" type="JarApplication" factoryName="JAR Application">
       <extension name="coverage" enabled="false" merge="false" sample_coverage="true" runner="idea" />
+      <envs />
+      <method />
+    </configuration>
+    <configuration default="true" type="Java Scratch" factoryName="Java Scratch">
+      <extension name="coverage" enabled="false" merge="false" sample_coverage="true" runner="idea" />
+      <option name="SCRATCH_FILE_ID" value="0" />
+      <option name="MAIN_CLASS_NAME" />
+      <option name="VM_PARAMETERS" />
+      <option name="PROGRAM_PARAMETERS" />
+      <option name="WORKING_DIRECTORY" />
+      <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
+      <option name="ALTERNATIVE_JRE_PATH" />
+      <option name="ENABLE_SWING_INSPECTOR" value="false" />
+      <option name="ENV_VARIABLES" />
+      <option name="PASS_PARENT_ENVS" value="true" />
+      <module name="" />
+      <envs />
+      <method />
+    </configuration>
+    <configuration default="true" type="JetRunConfigurationType" factoryName="Kotlin">
+      <extension name="coverage" enabled="false" merge="false" sample_coverage="true" runner="idea" />
+      <option name="MAIN_CLASS_NAME" />
+      <option name="VM_PARAMETERS" />
+      <option name="PROGRAM_PARAMETERS" />
+      <option name="WORKING_DIRECTORY" />
+      <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
+      <option name="ALTERNATIVE_JRE_PATH" />
+      <option name="PASS_PARENT_ENVS" value="true" />
+      <module name="AsposeIntelliJ" />
       <envs />
       <method />
     </configuration>
@@ -430,6 +484,34 @@
       <option name="PASS_PARENT_ENVS" value="true" />
       <option name="TEST_SEARCH_SCOPE">
         <value defaultName="moduleWithDependencies" />
+      </option>
+      <option name="USE_DEFAULT_REPORTERS" value="false" />
+      <option name="PROPERTIES_FILE" />
+      <envs />
+      <properties />
+      <listeners />
+      <method />
+    </configuration>
+    <configuration default="true" type="TestNGTestDiscovery" factoryName="TestNG Test Discovery" changeList="All">
+      <extension name="coverage" enabled="false" merge="false" sample_coverage="true" runner="idea" />
+      <module name="" />
+      <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
+      <option name="ALTERNATIVE_JRE_PATH" />
+      <option name="SUITE_NAME" />
+      <option name="PACKAGE_NAME" />
+      <option name="MAIN_CLASS_NAME" />
+      <option name="METHOD_NAME" />
+      <option name="GROUP_NAME" />
+      <option name="TEST_OBJECT" value="CLASS" />
+      <option name="VM_PARAMETERS" />
+      <option name="PARAMETERS" />
+      <option name="WORKING_DIRECTORY" />
+      <option name="OUTPUT_DIRECTORY" />
+      <option name="ANNOTATION_TYPE" />
+      <option name="ENV_VARIABLES" />
+      <option name="PASS_PARENT_ENVS" value="true" />
+      <option name="TEST_SEARCH_SCOPE">
+        <value defaultName="singleModule" />
       </option>
       <option name="USE_DEFAULT_REPORTERS" value="false" />
       <option name="PROPERTIES_FILE" />
@@ -480,7 +562,7 @@
     <servers />
   </component>
   <component name="ToolWindowManager">
-    <frame x="-8" y="-8" width="1378" height="744" extended-state="0" />
+    <frame x="-8" y="-8" width="1382" height="744" extended-state="6" />
     <editor active="false" />
     <layout>
       <window_info id="Palette" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.329429" sideWeight="0.5" order="3" side_tool="false" content_ui="tabs" />
@@ -493,7 +575,8 @@
       <window_info id="Run" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.22870663" sideWeight="0.8434191" order="2" side_tool="false" content_ui="tabs" />
       <window_info id="Terminal" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="14" side_tool="false" content_ui="tabs" />
       <window_info id="Designer" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="2" side_tool="false" content_ui="tabs" />
-      <window_info id="Project" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="true" show_stripe_button="true" weight="0.25110132" sideWeight="0.49918434" order="0" side_tool="false" content_ui="combo" />
+      <window_info id="Project" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="true" show_stripe_button="true" weight="0.24816984" sideWeight="0.49918434" order="0" side_tool="false" content_ui="combo" />
+      <window_info id="Find" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.22712934" sideWeight="0.76186943" order="1" side_tool="false" content_ui="tabs" />
       <window_info id="Structure" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.25" sideWeight="0.5" order="1" side_tool="false" content_ui="tabs" />
       <window_info id="Ant Build" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.25" sideWeight="0.5" order="5" side_tool="false" content_ui="tabs" />
       <window_info id="UI Designer" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.329429" sideWeight="0.5" order="2" side_tool="false" content_ui="tabs" />
@@ -511,7 +594,6 @@
       <window_info id="JFormDesigner Form Converter" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.32967034" sideWeight="0.5" order="15" side_tool="false" content_ui="tabs" />
       <window_info id="JFormDesigner Bindings" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.32967034" sideWeight="0.5" order="17" side_tool="false" content_ui="tabs" />
       <window_info id="Woko" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="11" side_tool="false" content_ui="tabs" />
-      <window_info id="Find" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.22778675" sideWeight="0.76186943" order="1" side_tool="false" content_ui="tabs" />
     </layout>
   </component>
   <component name="Vcs.Log.UiProperties">
@@ -694,24 +776,10 @@
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/src/com/aspose/wizards/AsposeWizardPanel.java">
-      <provider selected="true" editor-type-id="text-editor">
-        <state vertical-scroll-proportion="-21.543104">
-          <caret line="23" column="19" selection-start-line="23" selection-start-column="19" selection-end-line="23" selection-end-column="19" />
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/AsposeIntelliJ.iml">
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
           <caret line="14" column="9" selection-start-line="14" selection-start-column="9" selection-end-line="14" selection-end-column="9" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/com/aspose/utils/AsposeJavaComponent.java">
-      <provider selected="true" editor-type-id="text-editor">
-        <state vertical-scroll-proportion="0.33333334">
-          <caret line="197" column="16" selection-start-line="197" selection-start-column="16" selection-end-line="197" selection-end-column="16" />
         </state>
       </provider>
     </entry>
@@ -748,13 +816,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
           <caret line="46" column="41" selection-start-line="46" selection-start-column="31" selection-end-line="46" selection-end-column="41" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/com/aspose/examples/otherexamples/FrameWorkStatus.java">
-      <provider selected="true" editor-type-id="text-editor">
-        <state vertical-scroll-proportion="0.5405405">
-          <caret line="89" column="19" selection-start-line="89" selection-start-column="19" selection-end-line="89" selection-end-column="19" />
         </state>
       </provider>
     </entry>
@@ -807,13 +868,6 @@
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/src/com/aspose/examples/AsposeExamplePanel.java">
-      <provider selected="true" editor-type-id="text-editor">
-        <state vertical-scroll-proportion="1.1974359">
-          <caret line="129" column="10" selection-start-line="129" selection-start-column="10" selection-end-line="129" selection-end-column="10" />
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$USER_HOME$/intellij-community/intellij-community/platform/core-api/src/com/intellij/openapi/progress/Task.java">
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
@@ -842,31 +896,10 @@
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/src/com/aspose/examples/AsposeExampleDialog.java">
-      <provider selected="true" editor-type-id="text-editor">
-        <state vertical-scroll-proportion="0.0">
-          <caret line="109" column="0" selection-start-line="109" selection-start-column="0" selection-end-line="109" selection-end-column="0" />
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/src/com/aspose/examples/otherexamples/OtherExamples.java">
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
           <caret line="29" column="18" selection-start-line="29" selection-start-column="18" selection-end-line="29" selection-end-column="18" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/com/aspose/examples/otherexamples/OtherExamplesManager.java">
-      <provider selected="true" editor-type-id="text-editor">
-        <state vertical-scroll-proportion="0.0">
-          <caret line="76" column="75" selection-start-line="76" selection-start-column="75" selection-end-line="76" selection-end-column="75" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/com/aspose/examples/otherexamples/ExamplesFrameWork.java">
-      <provider selected="true" editor-type-id="text-editor">
-        <state vertical-scroll-proportion="0.0">
-          <caret line="143" column="13" selection-start-line="143" selection-start-column="13" selection-end-line="143" selection-end-column="13" />
         </state>
       </provider>
     </entry>
@@ -877,40 +910,93 @@
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/src/com/aspose/utils/AsposeJavaComponents.java">
+    <entry file="file://$PROJECT_DIR$/README.md">
       <provider selected="true" editor-type-id="text-editor">
-        <state vertical-scroll-proportion="0.1369637">
-          <caret line="21" column="0" selection-start-line="21" selection-start-column="0" selection-end-line="21" selection-end-column="0" />
-          <folding>
-            <element signature="n#!!doc" expanded="true" />
-            <element signature="imports" expanded="true" />
-          </folding>
+        <state vertical-scroll-proportion="0.029360967">
+          <caret line="24" column="0" selection-start-line="24" selection-start-column="0" selection-end-line="24" selection-end-column="0" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/com/aspose/examples/otherexamples/FrameWorkStatus.java">
+      <provider selected="true" editor-type-id="text-editor">
+        <state vertical-scroll-proportion="-10.148149">
+          <caret line="89" column="19" selection-start-line="89" selection-start-column="19" selection-end-line="89" selection-end-column="19" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/com/aspose/utils/AsposeJavaComponent.java">
+      <provider selected="true" editor-type-id="text-editor">
+        <state vertical-scroll-proportion="0.9805195">
+          <caret line="204" column="47" selection-start-line="204" selection-start-column="31" selection-end-line="204" selection-end-column="56" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/com/aspose/examples/otherexamples/ExamplesFrameWork.java">
+      <provider selected="true" editor-type-id="text-editor">
+        <state vertical-scroll-proportion="0.22294372">
+          <caret line="125" column="16" selection-start-line="125" selection-start-column="16" selection-end-line="125" selection-end-column="49" />
+          <folding />
         </state>
       </provider>
     </entry>
     <entry file="file://$PROJECT_DIR$/src/com/aspose/utils/GitHelper.java">
       <provider selected="true" editor-type-id="text-editor">
-        <state vertical-scroll-proportion="0.27062705">
-          <caret line="101" column="7" selection-start-line="101" selection-start-column="7" selection-end-line="101" selection-end-column="7" />
+        <state vertical-scroll-proportion="0.35402298">
+          <caret line="94" column="26" selection-start-line="94" selection-start-column="26" selection-end-line="94" selection-end-column="26" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/com/aspose/examples/AsposeExamplePanel.java">
+      <provider selected="true" editor-type-id="text-editor">
+        <state vertical-scroll-proportion="-1.0049261">
+          <caret line="332" column="36" selection-start-line="332" selection-start-column="36" selection-end-line="332" selection-end-column="36" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/com/aspose/examples/AsposeExampleDialog.java">
+      <provider selected="true" editor-type-id="text-editor">
+        <state vertical-scroll-proportion="0.45812806">
+          <caret line="103" column="71" selection-start-line="103" selection-start-column="71" selection-end-line="103" selection-end-column="71" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/com/aspose/wizards/AsposeWizardPanel.java">
+      <provider selected="true" editor-type-id="text-editor">
+        <state vertical-scroll-proportion="0.58850574">
+          <caret line="40" column="29" selection-start-line="40" selection-start-column="29" selection-end-line="40" selection-end-column="29" />
           <folding>
-            <element signature="e#0#2962#0" expanded="false" />
-            <element signature="imports" expanded="false" />
+            <element signature="imports" expanded="true" />
           </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/com/aspose/examples/otherexamples/OtherExamplesManager.java">
+      <provider selected="true" editor-type-id="text-editor">
+        <state vertical-scroll-proportion="0.0">
+          <caret line="59" column="9" selection-start-line="59" selection-start-column="9" selection-end-line="59" selection-end-column="9" />
+          <folding>
+            <element signature="imports" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/com/aspose/utils/AsposeJavaComponents.java">
+      <provider selected="true" editor-type-id="text-editor">
+        <state vertical-scroll-proportion="0.33333334">
+          <caret line="44" column="21" selection-start-line="44" selection-start-column="17" selection-end-line="44" selection-end-column="21" />
+          <folding />
         </state>
       </provider>
     </entry>
     <entry file="file://$PROJECT_DIR$/META-INF/plugin.xml">
       <provider selected="true" editor-type-id="text-editor">
-        <state vertical-scroll-proportion="-9.153846">
-          <caret line="20" column="14" selection-start-line="20" selection-start-column="14" selection-end-line="20" selection-end-column="14" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/README.md">
-      <provider selected="true" editor-type-id="text-editor">
-        <state vertical-scroll-proportion="-1.8202765">
-          <caret line="24" column="0" selection-start-line="24" selection-start-column="0" selection-end-line="24" selection-end-column="0" />
+        <state vertical-scroll-proportion="0.16091955">
+          <caret line="20" column="16" selection-start-line="20" selection-start-column="16" selection-end-line="20" selection-end-column="16" />
           <folding />
         </state>
       </provider>

--- a/Plugins/Aspose_for_JetBrains/META-INF/plugin.xml
+++ b/Plugins/Aspose_for_JetBrains/META-INF/plugin.xml
@@ -18,7 +18,7 @@
 <idea-plugin version="2">
   <id>com.aspose.intellijplugin.id</id>
   <name>Aspose Project Wizard</name>
-  <version>1.4</version>
+  <version>1.4.0</version>
   <vendor email="marketplace@aspose.com" url="http://www.aspose.com">Aspose Pty Ltd.</vendor>
 
 

--- a/Plugins/Aspose_for_JetBrains/src/com/aspose/examples/AsposeExampleDialog.java
+++ b/Plugins/Aspose_for_JetBrains/src/com/aspose/examples/AsposeExampleDialog.java
@@ -107,7 +107,7 @@ public class AsposeExampleDialog extends DialogWrapper {
                 for (OtherExamples _otherExample : asposeComponent.getOtherFrameworkExamples()) {
                     String examplesName = _otherExample.getExampleName();
                     if (destinationPath.contains(examplesName)) {
-                        destinationPath = destinationPath.replace(examplesName + "\\", "");
+                        destinationPath = destinationPath.replace(examplesName + File.separator, "");
                         OtherExamplesManager.installExamplesDependencies(_otherExample, projectPath,project);
                         break;
                     }

--- a/Plugins/Aspose_for_JetBrains/src/com/aspose/examples/AsposeExamplePanel.java
+++ b/Plugins/Aspose_for_JetBrains/src/com/aspose/examples/AsposeExamplePanel.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) Aspose 2002-2014. All Rights Reserved.
- *
+ * <p/>
  * LICENSE: This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; either version 3
@@ -14,7 +14,6 @@
  * see http://opensource.org/licenses/gpl-3.0.html
  *
  * @author Adeel Ilyas <adeel.ilyas@aspose.com>
- *
  */
 package com.aspose.examples;
 
@@ -45,8 +44,7 @@ import com.intellij.ui.treeStructure.Tree;
 /**
  * @author Adeel Ilyas
  */
-public final class AsposeExamplePanel extends JPanel
-{
+public final class AsposeExamplePanel extends JPanel {
     Project selectedProject;
     boolean examplesNotAvailable;
 
@@ -56,11 +54,11 @@ public final class AsposeExamplePanel extends JPanel
 
     boolean examplesDefinitionAvailable;
     AsposeExampleDialog dialog;
+
     /**
      * Creates new form AsposeExamplePanel
      */
-    public AsposeExamplePanel(AsposeExampleDialog dialog, Project selectedProject)
-    {
+    public AsposeExamplePanel(AsposeExampleDialog dialog, Project selectedProject) {
         AsposeConstants.println("AsposeExamplePanel is called ...");
         this.selectedProject = selectedProject;
         initComponents();
@@ -69,8 +67,7 @@ public final class AsposeExamplePanel extends JPanel
 
     }
 
-    private void initComponentsUser()
-    {
+    private void initComponentsUser() {
         examplesNotAvailable = false;
         examplesDefinitionAvailable = false;
         getComponentSelection().removeAllItems();
@@ -85,13 +82,11 @@ public final class AsposeExamplePanel extends JPanel
     }
 
     @Override
-    public String getName()
-    {
+    public String getName() {
         return "Aspose Java API and Example";
     }
 
-    private void initComponents()
-    {
+    private void initComponents() {
         ResourceBundle bundle = ResourceBundle.getBundle("Bundle");
         jPanel1 = new JPanel();
         jLabel2 = new JLabel();
@@ -148,10 +143,8 @@ public final class AsposeExamplePanel extends JPanel
         });
         jLabel1.setText(bundle.getString("AsposeExamplePanel.jLabel1.text"));
         jLabelMessage.setText(bundle.getString("AsposeExamplePanel.jLabelMessage.text"));
-        examplesTree.addMouseListener(new java.awt.event.MouseAdapter()
-        {
-            public void mouseClicked(java.awt.event.MouseEvent evt)
-            {
+        examplesTree.addMouseListener(new java.awt.event.MouseAdapter() {
+            public void mouseClicked(java.awt.event.MouseEvent evt) {
                 examplesTree_clicked(evt);
             }
         });
@@ -160,67 +153,62 @@ public final class AsposeExamplePanel extends JPanel
         javax.swing.GroupLayout layout = new javax.swing.GroupLayout(this);
         this.setLayout(layout);
         layout.setHorizontalGroup(
-            layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addComponent(jScrollPane1)
-            .addGroup(layout.createSequentialGroup()
-                .addComponent(jLabel1)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(componentSelection, javax.swing.GroupLayout.PREFERRED_SIZE, 198, javax.swing.GroupLayout.PREFERRED_SIZE))
-            .addComponent(jLabelMessage, javax.swing.GroupLayout.PREFERRED_SIZE, 361, javax.swing.GroupLayout.PREFERRED_SIZE)
-            .addComponent(jPanel1, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                        .addComponent(jScrollPane1)
+                        .addGroup(layout.createSequentialGroup()
+                                .addComponent(jLabel1)
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                .addComponent(componentSelection, javax.swing.GroupLayout.PREFERRED_SIZE, 198, javax.swing.GroupLayout.PREFERRED_SIZE))
+                        .addComponent(jLabelMessage, javax.swing.GroupLayout.PREFERRED_SIZE, 361, javax.swing.GroupLayout.PREFERRED_SIZE)
+                        .addComponent(jPanel1, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
         );
         layout.setVerticalGroup(
-            layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(layout.createSequentialGroup()
-                .addComponent(jPanel1, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
-                    .addComponent(componentSelection, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addComponent(jLabel1,javax.swing.GroupLayout.PREFERRED_SIZE, 23, javax.swing.GroupLayout.PREFERRED_SIZE))
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(jScrollPane1, javax.swing.GroupLayout.PREFERRED_SIZE, 229, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(jLabelMessage, javax.swing.GroupLayout.PREFERRED_SIZE, 20, javax.swing.GroupLayout.PREFERRED_SIZE))
+                layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                        .addGroup(layout.createSequentialGroup()
+                                .addComponent(jPanel1, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                                        .addComponent(componentSelection, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                        .addComponent(jLabel1, javax.swing.GroupLayout.PREFERRED_SIZE, 23, javax.swing.GroupLayout.PREFERRED_SIZE))
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                .addComponent(jScrollPane1, javax.swing.GroupLayout.PREFERRED_SIZE, 229, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                .addComponent(jLabelMessage, javax.swing.GroupLayout.PREFERRED_SIZE, 20, javax.swing.GroupLayout.PREFERRED_SIZE))
         );
     }
+
     //=========================================================================
     private void jLabel2ComponentResized(java.awt.event.ComponentEvent evt) {
         int labelwidth = jLabel2.getWidth();
         int labelheight = jLabel2.getHeight();
         Image img = icon.getImage();
-        jLabel2.setIcon( new ImageIcon(img.getScaledInstance(labelwidth,labelheight ,Image.SCALE_FAST)));
+        jLabel2.setIcon(new ImageIcon(img.getScaledInstance(labelwidth, labelheight, Image.SCALE_FAST)));
     }
-    public String getSelectedProjectRootPath()
-    {
+
+    public String getSelectedProjectRootPath() {
         return selectedProject.getBasePath();
     }
 
     //=========================================================================
-    void read()
-    {
+    void read() {
         AsposeConstants.println(" === New File Visual Panel.read() === " + selectedProject.getBaseDir().getName());
         populateComponentsList();
     }
 
     //=========================================================================
-    private boolean populateComponentsList()
-    {
+    private boolean populateComponentsList() {
         File file = new File(getSelectedProjectRootPath() + File.separator + "lib");
-        String[] directories = file.list(new FilenameFilter()
-        {
+        String[] directories = file.list(new FilenameFilter() {
             @Override
-            public boolean accept(File dir, String name)
-            {
+            public boolean accept(File dir, String name) {
                 return new File(dir, name).isDirectory();
             }
         });
 
         getComponentSelection().removeAllItems();
         getComponentSelection().addItem("Select API");
-        for (String directory : directories)
-        {
-            if (!directory.equals("CopyLibs") && !directory.equals("ExamplesFrameWorks"))
-            {
+        for (String directory : directories) {
+            if (!directory.equals("CopyLibs") && !directory.equals("ExamplesFrameWorks")) {
                 getComponentSelection().addItem(directory);
             }
         }
@@ -228,8 +216,7 @@ public final class AsposeExamplePanel extends JPanel
     }
 
     //=========================================================================
-    private void componentSelectionActionPerformed(java.awt.event.ActionEvent evt)
-    {
+    private void componentSelectionActionPerformed(java.awt.event.ActionEvent evt) {
         final String item = (String) getComponentSelection().getSelectedItem();
         CustomMutableTreeNode top = new CustomMutableTreeNode("");
         DefaultTreeModel model = (DefaultTreeModel) getExamplesTree().getModel();
@@ -237,7 +224,7 @@ public final class AsposeExamplePanel extends JPanel
         model.reload(top);
         if (item != null && !item.equals("Select API")) {
 
-            AsposeExampleCallback callback = new AsposeExampleCallback(this,top);
+            AsposeExampleCallback callback = new AsposeExampleCallback(this, top);
             final ModalTaskImpl modalTask = new ModalTaskImpl(selectedProject, callback, "Please wait...");
             ProgressManager.getInstance().run(modalTask);
             top.setTopTreeNodeText(item);
@@ -245,153 +232,128 @@ public final class AsposeExamplePanel extends JPanel
             model.reload(top);
             getExamplesTree().expandPath(new TreePath(top.getPath()));
 
-            }
+        }
         validateDialog();
     }
 
 //=========================================================================
 
     @Override
-    public void validate()
-    {
+    public void validate() {
         AsposeConstants.println("AsposeExamplePanel validate called..");
     }
 
-//=========================================================================
-    public boolean validateDialog()
-    {
-        if (isExampleSelected())
-        {
-            if (dialog!=null)
-            dialog.updateControls(true);
+    //=========================================================================
+    public boolean validateDialog() {
+        if (isExampleSelected()) {
+            if (dialog != null)
+                dialog.updateControls(true);
             clearMessage();
             return true;
         }
-        if (getComponentSelection().getSelectedIndex() == 0)
-        {
-            if (dialog!=null)
-            dialog.updateControls(false);
+        if (getComponentSelection().getSelectedIndex() == 0) {
+            if (dialog != null)
+                dialog.updateControls(false);
             diplayMessage("Please select API", true);
             return false;
-        }
-        else if (!isExampleSelected())
-        {
-            if (dialog!=null)
-            dialog.updateControls(false);
+        } else if (!isExampleSelected()) {
+            if (dialog != null)
+                dialog.updateControls(false);
             diplayMessage("Please select example", true);
             return false;
         }
-        if (dialog!=null)
-        dialog.updateControls(true);
+        if (dialog != null)
+            dialog.updateControls(true);
         clearMessage();
         return true;
     }
 
     //=========================================================================
-    private boolean isExampleSelected()
-    {
+    private boolean isExampleSelected() {
         CustomMutableTreeNode comp = (CustomMutableTreeNode) getExamplesTree().getLastSelectedPathComponent();
-        if (comp == null)
-        {
+        if (comp == null) {
             return false;
         }
-        try
-        {
+        try {
             Example ex = comp.getExample();
-            if (ex == null)
-            {
+            if (ex == null) {
                 return false;
             }
-        }
-        catch (Exception ex)
-        {
+        } catch (Exception ex) {
             return false;
         }
         return true;
     }
 
     //=========================================================================
-    public void diplayMessage(String message,boolean error) {
+    public void diplayMessage(String message, boolean error) {
 
-            if (error) {
-                jLabelMessage.setForeground(Color.RED);
-            } else {
-                jLabelMessage.setForeground(Color.GREEN);
-            }
-            jLabelMessage.setText(message);
+        if (error) {
+            jLabelMessage.setForeground(Color.RED);
+        } else {
+            jLabelMessage.setForeground(Color.GREEN);
+        }
+        jLabelMessage.setText(message);
     }
+
     //=========================================================================
-    private void clearMessage()
-    {
+    private void clearMessage() {
         jLabelMessage.setText("");
 
     }
 
     //=========================================================================
-    public int showMessage(String title, String message, int buttons, int icon)
-    {
+    public int showMessage(String title, String message, int buttons, int icon) {
         int result = JOptionPane.showConfirmDialog(null, message, title, buttons, icon);
         return result;
     }
 
     //=========================================================================
-    public void checkAndUpdateRepo(AsposeJavaComponent component,ProgressIndicator p)
-    {
-        if (null == component)
-        {
+    public void checkAndUpdateRepo(AsposeJavaComponent component, ProgressIndicator p) {
+        if (null == component) {
             return;
         }
-        if (null == component.get_remoteExamplesRepository())
-        {
+        if (null == component.get_remoteExamplesRepository()) {
             showMessage("Examples not available", component.get_name() + " - " + AsposeConstants.EXAMPLES_NOT_AVAILABLE_MESSAGE, JOptionPane.CLOSED_OPTION, JOptionPane.INFORMATION_MESSAGE);
             examplesNotAvailable = true;
             examplesDefinitionAvailable = false;
             return;
-        }
-        else
-        {
+        } else {
             examplesNotAvailable = false;
         }
 
-        if (GitHelper.isExamplesDefinitionsPresent(component))
-        {
-            try
-            {
-                  examplesDefinitionAvailable = true;
-                  p.setFraction(0.30);
+        if (GitHelper.isExamplesDefinitionsPresent(component)) {
+            try {
+
+                examplesDefinitionAvailable = true;
+
+                if (AsposeComponentsManager.isIneternetConnected()) {
+                    GitHelper.updateRepository(component, p); // Updates the local repository with new examples.
+                }
+                p.setFraction(0.30);
+            } catch (Exception e) {
             }
-            catch (Exception e)
-            {
+        } else {
+
+            if (AsposeComponentsManager.isIneternetConnected()) {
+                GitHelper.updateRepository(component, p);
+                if (GitHelper.isExamplesDefinitionsPresent(component)) {
+                    examplesDefinitionAvailable = true;
+
+                }
+            } else {
+                showMessage(AsposeConstants.INTERNET_CONNECTION_REQUIRED_MESSAGE_TITLE, component.get_name() + " - " + AsposeConstants.EXAMPLES_INTERNET_CONNECTION_REQUIRED_MESSAGE, JOptionPane.OK_OPTION, JOptionPane.INFORMATION_MESSAGE);
             }
         }
-
-        else
-        {
-
-                if (AsposeComponentsManager.isIneternetConnected())
-                {
-                    GitHelper.updateRepository(component,p);
-                    if (GitHelper.isExamplesDefinitionsPresent(component))
-                    {
-                        examplesDefinitionAvailable = true;
-
-                    }
-                }
-                else
-                {
-                    showMessage(AsposeConstants.INTERNET_CONNECTION_REQUIRED_MESSAGE_TITLE, component.get_name() + " - " + AsposeConstants.EXAMPLES_INTERNET_CONNECTION_REQUIRED_MESSAGE, JOptionPane.OK_OPTION, JOptionPane.INFORMATION_MESSAGE);
-                }
-             }
         p.setFraction(0.50);
     }
 
     //====================================================================
-    public  void populateExamplesTree(AsposeJavaComponent asposeComponent,CustomMutableTreeNode top,ProgressIndicator p)
+    public void populateExamplesTree(AsposeJavaComponent asposeComponent, CustomMutableTreeNode top, ProgressIndicator p)
 
     {
         String examplesDefinitionFile = GitHelper.getExamplesDefinitionsPath(asposeComponent);
-        try
-        {
+        try {
             JAXBContext jaxbContext = JAXBContext.newInstance(ObjectFactory.class);
             Unmarshaller unmarshaller;
 
@@ -406,26 +368,21 @@ public final class AsposeExamplePanel extends JPanel
             p.setFraction(0.7);
             // Integration of Apache POI Examples / Other FrameWork Examples
             // Add Apache POI related Aspose API (comparison) examples if available any.
-            OtherExamplesManager.addOtherExamples(top, asposeComponent,p);
+            OtherExamplesManager.addOtherExamples(top, asposeComponent, p);
             //
 
 
-        }
-        catch (JAXBException ex)
-        {
-          ex.printStackTrace();
+        } catch (JAXBException ex) {
+            ex.printStackTrace();
         }
     }
 
     //=========================================================================
-    void parseFoldersTree(List<Folders> rootFoldersList, CustomMutableTreeNode parentItem)
-    {
-        for (Folders folders : rootFoldersList)
-        {
+    void parseFoldersTree(List<Folders> rootFoldersList, CustomMutableTreeNode parentItem) {
+        for (Folders folders : rootFoldersList) {
             // Get list of folder
             List<Folder> folderList = folders.getFolder();
-            for (Folder folder : folderList)
-            {
+            for (Folder folder : folderList) {
                 CustomMutableTreeNode child = new CustomMutableTreeNode(folder.getTitle());
                 child.setExPath(parentItem.getExPath() + File.separator + folder.getFolderName());
                 parseExamples(folder.getExamples(), child);
@@ -436,13 +393,10 @@ public final class AsposeExamplePanel extends JPanel
     }
 
     //=========================================================================
-    void parseExamples(List<Examples> examplesList, CustomMutableTreeNode parentItem)
-    {
-        for (Examples examples : examplesList)
-        {
+    void parseExamples(List<Examples> examplesList, CustomMutableTreeNode parentItem) {
+        for (Examples examples : examplesList) {
             List<Example> exampleList = examples.getExample();
-            for (Example example : exampleList)
-            {
+            for (Example example : exampleList) {
                 // false: do not run
                 parseExample(example, parentItem);
             }
@@ -450,8 +404,7 @@ public final class AsposeExamplePanel extends JPanel
     }
 
     //=========================================================================
-    void parseExample(Example example, CustomMutableTreeNode parentItem)
-    {
+    void parseExample(Example example, CustomMutableTreeNode parentItem) {
         CustomMutableTreeNode child = new CustomMutableTreeNode(example.getTitle());
         child.setExample(example);
         child.setExPath(parentItem.getExPath() + File.separator + example.getFolderName());
@@ -459,10 +412,10 @@ public final class AsposeExamplePanel extends JPanel
     }
 
     //=========================================================================
-    private void componentSelection_Propertychanged(java.beans.PropertyChangeEvent evt)
-    {
+    private void componentSelection_Propertychanged(java.beans.PropertyChangeEvent evt) {
 
     }
+
     //=========================================================================
     private void examplesTree_clicked(java.awt.event.MouseEvent evt)//GEN-FIRST:event_examplesTree_clicked
     {
@@ -471,6 +424,7 @@ public final class AsposeExamplePanel extends JPanel
 
         validateDialog();
     }
+
     // Variables declaration
     private javax.swing.JComboBox componentSelection;
     private javax.swing.JTree examplesTree;
@@ -485,16 +439,14 @@ public final class AsposeExamplePanel extends JPanel
     /**
      * @return the examplesTree
      */
-    public javax.swing.JTree getExamplesTree()
-    {
+    public javax.swing.JTree getExamplesTree() {
         return examplesTree;
     }
 
     /**
      * @return the componentSelection
      */
-    public javax.swing.JComboBox getComponentSelection()
-    {
+    public javax.swing.JComboBox getComponentSelection() {
         return componentSelection;
     }
 }

--- a/Plugins/Aspose_for_JetBrains/src/com/aspose/examples/otherexamples/OtherExamplesManager.java
+++ b/Plugins/Aspose_for_JetBrains/src/com/aspose/examples/otherexamples/OtherExamplesManager.java
@@ -48,15 +48,15 @@ public class OtherExamplesManager {
 
         //Defining FrameWork Lib Dependencies:
         poiFrameWork.addLibDependency(new LibDependency("dom4j-1.6.1.jar", "https://raw.githubusercontent.com/asposemarketplace/Aspose_for_Apache_POI/master/lib/ApachePOI/dom4j-1.6.1.jar"));
-        poiFrameWork.addLibDependency(new LibDependency("poi-3.11-beta1-20140306.jar", "https://raw.githubusercontent.com/asposemarketplace/Aspose_for_Apache_POI/master/lib/ApachePOI/poi-3.11-beta1-20140306.jar"));
-        poiFrameWork.addLibDependency(new LibDependency("poi-ooxml-3.11-beta1-20140306.jar", "https://raw.githubusercontent.com/asposemarketplace/Aspose_for_Apache_POI/master/lib/ApachePOI/poi-ooxml-3.11-beta1-20140306.jar"));
-        poiFrameWork.addLibDependency(new LibDependency("poi-ooxml-schemas-3.11-beta1-20140306.jar", "https://raw.githubusercontent.com/asposemarketplace/Aspose_for_Apache_POI/master/lib/ApachePOI/poi-ooxml-schemas-3.11-beta1-20140306.jar"));
-        poiFrameWork.addLibDependency(new LibDependency("poi-scratchpad-3.11-beta1-20140306.jar", "https://raw.githubusercontent.com/asposemarketplace/Aspose_for_Apache_POI/master/lib/ApachePOI/poi-scratchpad-3.11-beta1-20140306.jar"));
-        poiFrameWork.addLibDependency(new LibDependency("xmlbeans-2.3.0.jar", "https://raw.githubusercontent.com/asposemarketplace/Aspose_for_Apache_POI/master/lib/ApachePOI/xmlbeans-2.3.0.jar"));
-
-        poiFrameWork.addLibDependency(new LibDependency("poi-examples-3.11-beta1-20140306.jar", "https://raw.githubusercontent.com/asposemarketplace/Aspose_for_Apache_POI/master/lib/ApachePOI/poi-examples-3.11-beta1-20140306.jar"));
-        poiFrameWork.addLibDependency(new LibDependency("poi-excelant-3.11-beta1-20140306.jar", "https://raw.githubusercontent.com/asposemarketplace/Aspose_for_Apache_POI/master/lib/ApachePOI/poi-excelant-3.11-beta1-20140306.jar"));
+        poiFrameWork.addLibDependency(new LibDependency("xmlbeans-2.6.0.jar", "https://raw.githubusercontent.com/asposemarketplace/Aspose_for_Apache_POI/master/lib/ApachePOI/xmlbeans-2.6.0.jar"));
         poiFrameWork.addLibDependency(new LibDependency("stax-api-1.0.1.jar", "https://raw.githubusercontent.com/asposemarketplace/Aspose_for_Apache_POI/master/lib/ApachePOI/stax-api-1.0.1.jar"));
+
+        poiFrameWork.addLibDependency(new LibDependency("poi-3.11.jar", "https://raw.githubusercontent.com/asposemarketplace/Aspose_for_Apache_POI/master/lib/ApachePOI/poi-3.11-20141221.jar"));
+        poiFrameWork.addLibDependency(new LibDependency("poi-ooxml-3.11.jar", "https://raw.githubusercontent.com/asposemarketplace/Aspose_for_Apache_POI/master/lib/ApachePOI/poi-ooxml-3.11-20141221.jar"));
+        poiFrameWork.addLibDependency(new LibDependency("poi-ooxml-schemas-3.11.jar", "https://raw.githubusercontent.com/asposemarketplace/Aspose_for_Apache_POI/master/lib/ApachePOI/poi-ooxml-schemas-3.11-20141221.jar"));
+        poiFrameWork.addLibDependency(new LibDependency("poi-scratchpad-3.11.jar", "https://raw.githubusercontent.com/asposemarketplace/Aspose_for_Apache_POI/master/lib/ApachePOI/poi-scratchpad-3.11-20141221.jar"));
+        poiFrameWork.addLibDependency(new LibDependency("poi-examples-3.11.jar", "https://raw.githubusercontent.com/asposemarketplace/Aspose_for_Apache_POI/master/lib/ApachePOI/poi-examples-3.11-20141221.jar"));
+        poiFrameWork.addLibDependency(new LibDependency("poi-excelant-3.11.jar", "https://raw.githubusercontent.com/asposemarketplace/Aspose_for_Apache_POI/master/lib/ApachePOI/poi-excelant-3.11-20141221.jar"));
         return poiFrameWork;
     }
 


### PR DESCRIPTION
New Features
1.  Aspose.OCR for Java Examples are now available in Aspose Examples Wizard of your favorite InteliJ IDEA
2.  Aspose.OCR for Java Examples are now available in Aspose Examples Wizard of your favorite InteliJ IDEA
3.  More Aspose.Slides Examples comparing features of Apache POI HSLF and XSLF.
4.  More Aspose.Words Examples with Missing Features of Apache POI HWPF and XWPF.
5.  Aspose.Cells Examples showing Missing Features of Apache POI HSSF and XSSF.
6.  Supports and Tested with latest IntelliJ IDEA v.14.0.1, v.14.1.5 and v.15.0.1
7.  Necessary update for Aspose Examples wizard since examples may not appear proper with older versions of plugin.

Signed-off-by: AdeelIlyas2014 adeel.ilyas@aspose.com
